### PR TITLE
Fixes an issue with generation of the CMakeLists.txt file

### DIFF
--- a/pico_project.py
+++ b/pico_project.py
@@ -865,6 +865,7 @@ def GenerateCMake(folder, params):
     # seemingly a bit easier to handle than the backslashes
 
     p = str(params.sdkPath).replace('\\','/')
+    p = '\"' + p + '\"'
 
     file.write('set(PICO_SDK_PATH ' + p + ')\n\n')
     file.write(cmake_header2)


### PR DESCRIPTION
When CMakeLists.txt is generated quotes are not inserted before and after the path meaning that if there is a space in the SDK path cmake fails to generate the build files.
This pull requests adds a simple fix for that.