### PR TITLE
Create an "include" folder

### DIFF
--- a/pico_project.py
+++ b/pico_project.py
@@ -939,9 +939,9 @@ def GenerateCMake(folder, params):
     executableName = params.projectName
 
     if params.wantCPP:
-        file.write('add_executable(' + params.projectName + ' ' + params.projectName + '.cpp )\n\n')
+        file.write('add_executable(' + params.projectName + ' ' + params.projectName + '.cpp include/*)\n\n')
     else:
-        file.write('add_executable(' + params.projectName + ' ' + params.projectName + '.c )\n\n')
+        file.write('add_executable(' + params.projectName + ' ' + params.projectName + '.c include/*)\n\n')
 
     file.write('pico_set_program_name(' + params.projectName + ' "' + executableName + '")\n')
     file.write('pico_set_program_version(' + params.projectName + ' "0.1")\n\n')

--- a/pico_project.py
+++ b/pico_project.py
@@ -938,7 +938,7 @@ def GenerateCMake(folder, params):
     # No GUI/command line to set a different executable name at this stage
     executableName = params.projectName
     
-    file.write('file(GLOB INCLUDES "*.c" "*.C" "*.c++" "*.cc" "*.cpp" "*.cxx" "*.cu" "*.m" "*.M" "*.mm" "*.h" "*.hh" "*.h++" "*.hm" "*.hpp" "*.hxx" "*.in" "*.txx")\n')
+    file(GLOB INCLUDES "include/*.c" "include/*.C" "include/*.c++" "include/*.cc" "include/*.cpp" "include/*.cxx" "include/*.cu" "include/*.m" "include/*.M" "include/*.mm" "include/*.h" "include/*.hh" "include/*.h++" "include/*.hm" "include/*.hpp" "include/*.hxx" "include/*.in" "include/*.txx")
 
     if params.wantCPP:
         file.write('add_executable(' + params.projectName + ' ' + params.projectName + '.cpp ${INCLUDES})\n\n')

--- a/pico_project.py
+++ b/pico_project.py
@@ -937,11 +937,13 @@ def GenerateCMake(folder, params):
 
     # No GUI/command line to set a different executable name at this stage
     executableName = params.projectName
+    
+    file.write('file(GLOB INCLUDES "*.c" "*.C" "*.c++" "*.cc" "*.cpp" "*.cxx" "*.cu" "*.m" "*.M" "*.mm" "*.h" "*.hh" "*.h++" "*.hm" "*.hpp" "*.hxx" "*.in" "*.txx")\n')
 
     if params.wantCPP:
-        file.write('add_executable(' + params.projectName + ' ' + params.projectName + '.cpp include/*)\n\n')
+        file.write('add_executable(' + params.projectName + ' ' + params.projectName + '.cpp ${INCLUDES})\n\n')
     else:
-        file.write('add_executable(' + params.projectName + ' ' + params.projectName + '.c include/*)\n\n')
+        file.write('add_executable(' + params.projectName + ' ' + params.projectName + '.c ${INCLUDES})\n\n')
 
     file.write('pico_set_program_name(' + params.projectName + ' "' + executableName + '")\n')
     file.write('pico_set_program_version(' + params.projectName + ' "0.1")\n\n')

--- a/pico_project.py
+++ b/pico_project.py
@@ -924,6 +924,10 @@ def GenerateCMake(folder, params):
 
     file.write(cmake_header3)
 
+    #Add a folder with your own libraries
+    file.write('#Folder for your own libraries\n')
+    file.write('include_directories(include)\n')
+
     # add the preprocessor defines for overall configuration
     if params.configs:
         file.write('# Add any PICO_CONFIG entries specified in the Advanced settings\n')
@@ -1053,6 +1057,9 @@ def generateProjectFiles(projectPath, projectName, sdkPath, projects, debugger):
                    '               },\n'
                    '     },\n'
                    '}\n')
+
+            # Create a Include folder
+            os.mkdir("include")
 
             # Create a build folder, and run our cmake project build from it
             if not os.path.exists(VSCODE_FOLDER):


### PR DESCRIPTION
The change I propose is that a "include" folder will be created for each project and consider it in the "CMakeLists.txt" file, which will allow you to easily add your own libraries to the project. To add a library, just paste it into the "include" folder and add the `#include` line in the main project file, for example: `#include "include/lcd.h "`