### PR TITLE
Add "include" folder

### DIFF
--- a/pico_project.py
+++ b/pico_project.py
@@ -938,7 +938,7 @@ def GenerateCMake(folder, params):
     # No GUI/command line to set a different executable name at this stage
     executableName = params.projectName
     
-    file(GLOB INCLUDES "include/*.c" "include/*.C" "include/*.c++" "include/*.cc" "include/*.cpp" "include/*.cxx" "include/*.cu" "include/*.m" "include/*.M" "include/*.mm" "include/*.h" "include/*.hh" "include/*.h++" "include/*.hm" "include/*.hpp" "include/*.hxx" "include/*.in" "include/*.txx")
+    file.write('file(GLOB INCLUDES "include/*.c" "include/*.C" "include/*.c++" "include/*.cc" "include/*.cpp" "include/*.cxx" "include/*.cu" "include/*.m" "include/*.M" "include/*.mm" "include/*.h" "include/*.hh" "include/*.h++" "include/*.hm" "include/*.hpp" "include/*.hxx" "include/*.in" "include/*.txx")\n')
 
     if params.wantCPP:
         file.write('add_executable(' + params.projectName + ' ' + params.projectName + '.cpp ${INCLUDES})\n\n')

--- a/pico_project.py
+++ b/pico_project.py
@@ -30,6 +30,7 @@ VSCODE_LAUNCH_FILENAME = 'launch.json'
 VSCODE_C_PROPERTIES_FILENAME = 'c_cpp_properties.json'
 VSCODE_SETTINGS_FILENAME ='settings.json'
 VSCODE_FOLDER='.vscode'
+INCLUDE_FOLDER='include'
 
 CONFIG_UNSET="Not set"
 
@@ -1060,9 +1061,6 @@ def generateProjectFiles(projectPath, projectName, sdkPath, projects, debugger):
                    '     },\n'
                    '}\n')
 
-            # Create a Include folder
-            os.mkdir("include")
-
             # Create a build folder, and run our cmake project build from it
             if not os.path.exists(VSCODE_FOLDER):
                 os.mkdir(VSCODE_FOLDER)
@@ -1151,6 +1149,10 @@ def DoEverything(parent, params):
     GenerateMain('.', params.projectName, features_and_examples, params.wantCPP)
 
     GenerateCMake('.', params)
+    
+    # Create a Include folder
+    if not os.path.exists(INCLUDE_FOLDER):
+        os.mkdir(INCLUDE_FOLDER)
 
     # Create a build folder, and run our cmake project build from it
     if not os.path.exists('build'):

--- a/pico_project.py
+++ b/pico_project.py
@@ -924,6 +924,10 @@ def GenerateCMake(folder, params):
 
     file.write(cmake_header3)
 
+    #Add a folder with your own libraries
+    file.write('#Folder for your own libraries\n')
+    file.write('include_directories(include)\n')
+
     # add the preprocessor defines for overall configuration
     if params.configs:
         file.write('# Add any PICO_CONFIG entries specified in the Advanced settings\n')
@@ -933,11 +937,13 @@ def GenerateCMake(folder, params):
 
     # No GUI/command line to set a different executable name at this stage
     executableName = params.projectName
+    
+    file(GLOB INCLUDES "include/*.c" "include/*.C" "include/*.c++" "include/*.cc" "include/*.cpp" "include/*.cxx" "include/*.cu" "include/*.m" "include/*.M" "include/*.mm" "include/*.h" "include/*.hh" "include/*.h++" "include/*.hm" "include/*.hpp" "include/*.hxx" "include/*.in" "include/*.txx")
 
     if params.wantCPP:
-        file.write('add_executable(' + params.projectName + ' ' + params.projectName + '.cpp )\n\n')
+        file.write('add_executable(' + params.projectName + ' ' + params.projectName + '.cpp ${INCLUDES})\n\n')
     else:
-        file.write('add_executable(' + params.projectName + ' ' + params.projectName + '.c )\n\n')
+        file.write('add_executable(' + params.projectName + ' ' + params.projectName + '.c ${INCLUDES})\n\n')
 
     file.write('pico_set_program_name(' + params.projectName + ' "' + executableName + '")\n')
     file.write('pico_set_program_version(' + params.projectName + ' "0.1")\n\n')
@@ -1053,6 +1059,9 @@ def generateProjectFiles(projectPath, projectName, sdkPath, projects, debugger):
                    '               },\n'
                    '     },\n'
                    '}\n')
+
+            # Create a Include folder
+            os.mkdir("include")
 
             # Create a build folder, and run our cmake project build from it
             if not os.path.exists(VSCODE_FOLDER):


### PR DESCRIPTION
Thanks to my changes, you can easily add your own libraries to each new project. Just copy the files to the "include" folder and in the main project file add the line `#include`, for example `#include "include/lcd.h"`. CMakeLists.txt should automatically take into account the appropriate files in the include folder.