### PR TITLE
Add argument for path to pico_configs file

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,10 @@ optional arguments:
                         Generate projects files for IDE. Options are: vscode
   -r, --runFromRAM      Run the program from RAM rather than flash
   -uart, --uart         Console output to UART (default)
-<<<<<<< HEAD
   -nouart, --nouart     Disable console output to UART
   -usb, --usb           Console output to USB (disables other USB functionality)
    cpp, --cpp           Generate C++ code
   -d DEBUGGER, --debugger DEBUGGER   Select debugger (0 = SWD, 1 = PicoProbe)
-=======
-  -usb, --usb           Console output to USB (disables other USB functionality
->>>>>>> 5ba387a (update README help with new option)
 ```
 You can list the features supported by the tools by using `./pico_project --list`. These features can
 be added to the project using the `--feature` options, this can be used multiple times.

--- a/README.md
+++ b/README.md
@@ -35,10 +35,14 @@ optional arguments:
                         Generate projects files for IDE. Options are: vscode
   -r, --runFromRAM      Run the program from RAM rather than flash
   -uart, --uart         Console output to UART (default)
+<<<<<<< HEAD
   -nouart, --nouart     Disable console output to UART
   -usb, --usb           Console output to USB (disables other USB functionality)
    cpp, --cpp           Generate C++ code
   -d DEBUGGER, --debugger DEBUGGER   Select debugger (0 = SWD, 1 = PicoProbe)
+=======
+  -usb, --usb           Console output to USB (disables other USB functionality
+>>>>>>> 5ba387a (update README help with new option)
 ```
 You can list the features supported by the tools by using `./pico_project --list`. These features can
 be added to the project using the `--feature` options, this can be used multiple times.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -t TSV, --tsv TSV     Set an alternative pico_configs.tsv file
+  -t TSV, --tsv TSV     Select an alternative pico_configs.tsv file
   -o OUTPUT, --output OUTPUT
                         Set an alternative CMakeList.txt filename
   -x, --examples        Add example code for the Pico standard library

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It will also add example code for any features and optionally for some standard 
 Running `./pico_project --help` will give a list of the available command line parameters
 
 ```
-usage: pico_project.py [-h] [-o OUTPUT] [-x] [-l] [-c] [-f FEATURE] [-over] [-b] [-g] [-p PROJECT] [-r] [-uart] [-usb] [name]
+usage: pico_project.py [-h] [-t TSV] [-o OUTPUT] [-x] [-l] [-c] [-f FEATURE] [-over] [-b] [-g] [-p PROJECT] [-r] [-uart] [-usb] [name]
 
 Pico Project generator
 
@@ -20,6 +20,7 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  -t TSV, --tsv TSV     Set an alternative pico_configs.tsv file
   -o OUTPUT, --output OUTPUT
                         Set an alternative CMakeList.txt filename
   -x, --examples        Add example code for the Pico standard library

--- a/pico_project.py
+++ b/pico_project.py
@@ -799,6 +799,7 @@ def CheckSDKPath(gui):
 def ParseCommandLine():
     parser = argparse.ArgumentParser(description='Pico Project generator')
     parser.add_argument("name", nargs="?", help="Name of the project")
+    parser.add_argument("-t", "--tsv", help="Set an alternative pico_configs.tsv file", default="pico_configs.tsv")
     parser.add_argument("-o", "--output", help="Set an alternative CMakeList.txt filename", default="CMakeLists.txt")
     parser.add_argument("-x", "--examples", action='store_true', help="Add example code for the Pico standard library")
     parser.add_argument("-l", "--list", action='store_true', help="List available features")
@@ -1101,7 +1102,7 @@ def generateProjectFiles(projectPath, projectName, sdkPath, projects, debugger):
 
 def LoadConfigurations():
     try:
-        with open("pico_configs.tsv") as tsvfile:
+        with open(args.tsv) as tsvfile:
             reader = csv.DictReader(tsvfile, dialect='excel-tab')
             for row in reader:
                 configuration_dictionary.append(row)

--- a/pico_project.py
+++ b/pico_project.py
@@ -799,7 +799,7 @@ def CheckSDKPath(gui):
 def ParseCommandLine():
     parser = argparse.ArgumentParser(description='Pico Project generator')
     parser.add_argument("name", nargs="?", help="Name of the project")
-    parser.add_argument("-t", "--tsv", help="Set an alternative pico_configs.tsv file", default="pico_configs.tsv")
+    parser.add_argument("-t", "--tsv", help="Select an alternative pico_configs.tsv file", default="pico_configs.tsv")
     parser.add_argument("-o", "--output", help="Set an alternative CMakeList.txt filename", default="CMakeLists.txt")
     parser.add_argument("-x", "--examples", action='store_true', help="Add example code for the Pico standard library")
     parser.add_argument("-l", "--list", action='store_true', help="List available features")


### PR DESCRIPTION
The path to `pico_configs.tsv` is hard-coded in the generator script. It complains when I use the generator in other scripts and even when I symlinked the script to my `PATH` for convenience. An option to specify where to find it will remove all this hassle. This PR aims to do just that.