### PR TITLE
cmake-configuration: remove hidden-attribute from 'build' and 'buildTarget'

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ The tool will generate all required CMake files, program files and VSCode IDE fi
 
 It will also add example code for any features and optionally for some standard library functions.
 
+## Installation
+
+To install this tool, execute the following commands (assuming `/usr/local/bin` is in your `PATH`):
+
+    sudo cp -a pico_project.py pico_configs.tsv logo_alpha.gif /usr/local/bin
+    sudo chown root:root  /usr/local/bin/{pico_project.py,pico_configs.tsv,logo_alpha.gif}
+
 ## Command line
 
 Running `./pico_project --help` will give a list of the available command line parameters

--- a/README.md
+++ b/README.md
@@ -84,10 +84,7 @@ Create VSCode Project | As well as the CMake files, also create the appropriate 
 Debugger | Use the specified debugger in the IDE
 
 
+## Tasks
 
-
-
-
-
-
-
+This command will also generate the file `.vscode/tasks.json` with (currently) a single task called `Copy to Pico`. If you run this task, it will compile, link and
+copy (upload) the code to the Pico. The extension called `Tasks` from the marketplace (author actboy168, note that there are other, similarly named extensions, so take care)  will add a button to the action-bar at the bottom of VSCode, so compiling and uploading is only a mouse-click away.

--- a/pico_project.py
+++ b/pico_project.py
@@ -1054,12 +1054,6 @@ def generateProjectFiles(projectPath, projectName, sdkPath, projects, debugger):
                    '    "launch" : {\n'
                    '      "visibility": "hidden"\n'
                    '               },\n'
-                   '    "build" : {\n'
-                   '      "visibility": "hidden"\n'
-                   '               },\n'
-                   '    "buildTarget" : {\n'
-                   '      "visibility": "hidden"\n'
-                   '               },\n'
                    '     },\n'
                    '}\n')
 

--- a/pico_project.py
+++ b/pico_project.py
@@ -27,6 +27,7 @@ CMAKELIST_FILENAME='CMakeLists.txt'
 COMPILER_NAME='arm-none-eabi-gcc'
 
 VSCODE_LAUNCH_FILENAME = 'launch.json'
+VSCODE_TASKS_FILENAME = 'tasks.json'
 VSCODE_C_PROPERTIES_FILENAME = 'c_cpp_properties.json'
 VSCODE_SETTINGS_FILENAME ='settings.json'
 VSCODE_EXTENSIONS_FILENAME ='extensions.json'
@@ -1027,6 +1028,40 @@ def generateProjectFiles(projectPath, projectName, sdkPath, projects, debugger):
                   '  ]\n'
                   '}\n')
 
+            t1 = ('{\n'
+                  '  // See https://go.microsoft.com/fwlink/?LinkId=733558\n'
+                  '  // for the documentation about the tasks.json format\n'
+                  '  "version": "2.0.0",\n'
+                  '  "tasks": [\n'
+                  '     {\n'
+                  '         "label": "Copy to Pico",\n'
+                  '         "type": "process",\n'
+                  '         "problemMatcher": [],\n'
+                  '         "options": {\n'
+                  '             "cwd": "${workspaceFolder}"\n'
+                  '         },\n'
+                  '         "command": "openocd",\n'
+                  '         "args": [\n'
+                  '             "-f",\n'
+                  '             "interface/raspberrypi-swd.cfg",\n'
+                  '             "-f",\n'
+                  '             "target/rp2040.cfg",\n'
+                  '             "-c",\n'
+                  '             "program ${command:cmake.launchTargetPath} verify reset exit"\n'
+                  '         ],\n'
+                  '         "group": "none",\n'
+                  '         "presentation": {\n'
+                  '             "echo": true,\n'
+                  '             "reveal": "always",\n'
+                  '             "focus": false,\n'
+                  '             "panel": "shared",\n'
+                  '             "showReuseMessage": false,\n'
+                  '             "clear": false\n'
+                  '         },\n'
+                  '     }\n'
+                  ' ]\n'
+                  '}\n')
+
             c1 = ('{\n'
                   '  "configurations": [\n'
                   '    {\n'
@@ -1075,6 +1110,11 @@ def generateProjectFiles(projectPath, projectName, sdkPath, projects, debugger):
             filename = VSCODE_LAUNCH_FILENAME
             file = open(filename, 'w')
             file.write(v1)
+            file.close()
+
+            filename = VSCODE_TASKS_FILENAME
+            file = open(filename, 'w')
+            file.write(t1)
             file.close()
 
             file = open(VSCODE_C_PROPERTIES_FILENAME, 'w')

--- a/pico_project.py
+++ b/pico_project.py
@@ -797,9 +797,10 @@ def CheckSDKPath(gui):
 
 
 def ParseCommandLine():
+    default_tsv = os.path.join(os.path.dirname(__file__), "pico_configs.tsv")
     parser = argparse.ArgumentParser(description='Pico Project generator')
     parser.add_argument("name", nargs="?", help="Name of the project")
-    parser.add_argument("-t", "--tsv", help="Select an alternative pico_configs.tsv file", default="pico_configs.tsv")
+    parser.add_argument("-t", "--tsv", help="Select an alternative pico_configs.tsv file", default=default_tsv)
     parser.add_argument("-o", "--output", help="Set an alternative CMakeList.txt filename", default="CMakeLists.txt")
     parser.add_argument("-x", "--examples", action='store_true', help="Add example code for the Pico standard library")
     parser.add_argument("-l", "--list", action='store_true', help="List available features")

--- a/pico_project.py
+++ b/pico_project.py
@@ -894,7 +894,13 @@ def GenerateCMake(folder, params):
                 )
 
     cmake_header2 = ("# Pull in Raspberry Pi Pico SDK (must be before project)\n"
-                "include(pico_sdk_import.cmake)\n\n"
+                "include(pico_sdk_import.cmake)\n"
+                "find_program(ELF2UF2_BIN ELF2UF2)\n"
+                "if(ELF2UF2_BIN)\n"
+                "  message(\"ELF2UF2 will not be built\")\n"
+                "  message(STATUS \"using: ${ELF2UF2_BIN}\")\n"
+                "  set(ELF2UF2_FOUND 1)\n"
+                "endif()\n\n"
                 )
 
     cmake_header3 = (

--- a/pico_project.py
+++ b/pico_project.py
@@ -894,13 +894,7 @@ def GenerateCMake(folder, params):
                 )
 
     cmake_header2 = ("# Pull in Raspberry Pi Pico SDK (must be before project)\n"
-                "include(pico_sdk_import.cmake)\n"
-                "find_program(ELF2UF2_BIN ELF2UF2)\n"
-                "if(ELF2UF2_BIN)\n"
-                "  message(\"ELF2UF2 will not be built\")\n"
-                "  message(STATUS \"using: ${ELF2UF2_BIN}\")\n"
-                "  set(ELF2UF2_FOUND 1)\n"
-                "endif()\n\n"
+                "include(pico_sdk_import.cmake)\n\n"
                 )
 
     cmake_header3 = (


### PR DESCRIPTION
Hiding build and buildTarget from the action-bar does not make sense:

  - starting a build with a single click is a regular task
  - changing the target also

Although the 'clean'-target currently seems to do nothing, I expect some improvements in the cmake-setup of the pico-SDK and then switching to the clean-target would be very useful.