### PR TITLE
Read files from original path if running via symlink

### DIFF
--- a/pico_project.py
+++ b/pico_project.py
@@ -600,7 +600,7 @@ class ProjectWindow(tk.Frame):
         mainFrame = tk.Frame(self, bg=GetBackground()).grid(row=0, column=0, columnspan=6, rowspan=12)
 
         # Need to keep a reference to the image or it will not appear.
-        self.logo = tk.PhotoImage(file=self._get_filepath("logo_alpha.gif"))
+        self.logo = tk.PhotoImage(file=GetFilePath("logo_alpha.gif"))
         logowidget = ttk.Label(mainFrame, image=self.logo, borderwidth=0, relief="solid").grid(row=0,column=0, columnspan=5, pady=10)
 
         namelbl = ttk.Label(mainFrame, text='Project Name :').grid(row=2, column=0, sticky=tk.E)
@@ -764,9 +764,6 @@ class ProjectWindow(tk.Frame):
         # Run the configuration window
         self.configs = ConfigurationWindow(self, self.configs).get()
 
-    def _get_filepath(self, filename):
-        return os.path.join(os.path.dirname(__file__), filename)
-
 def CheckPrerequisites():
     global isMac, isWindows
     isMac = (platform.system() == 'Darwin')
@@ -795,11 +792,17 @@ def CheckSDKPath(gui):
 
     return sdkPath
 
+def GetFilePath(filename):
+    if os.path.islink(__file__):
+        script_file = os.readlink(__file__)
+    else:
+        script_file = __file__
+    return os.path.join(os.path.dirname(script_file), filename)
 
 def ParseCommandLine():
     parser = argparse.ArgumentParser(description='Pico Project generator')
     parser.add_argument("name", nargs="?", help="Name of the project")
-    parser.add_argument("-t", "--tsv", help="Select an alternative pico_configs.tsv file", default="pico_configs.tsv")
+    parser.add_argument("-t", "--tsv", help="Select an alternative pico_configs.tsv file", default=GetFilePath("pico_configs.tsv"))
     parser.add_argument("-o", "--output", help="Set an alternative CMakeList.txt filename", default="CMakeLists.txt")
     parser.add_argument("-x", "--examples", action='store_true', help="Add example code for the Pico standard library")
     parser.add_argument("-l", "--list", action='store_true', help="List available features")


### PR DESCRIPTION
Hello,

This is a small change that allows `pico_project.py` to work properly even when run via a symlink. This is useful for users that have a `~/bin` directory in their `$PATH` with symlinks to the actual programs.

Please feel free to ignore this PR if you think this use case is too specific to support.