### PR TITLE
Add basic integration tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,7 @@ name: Run tests
 on: [push, pull_request]
 
 jobs:
-  tests:
+  pytest:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout pico-sdk/develop
@@ -18,8 +18,20 @@ jobs:
     - name: Install toolchain dependencies
       run:  sudo apt install cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential libstdc++-arm-none-eabi-newlib
 
-    - name: Hello
-      run: pwd && echo $SHELL 
+    - name: Checkout pico-project-generator
+      uses: actions/checkout@v2
+      with:
+        path: pico-project-generator
+
+    - name: Install project generator dependencies
+      run: cd pico-project-generator && python3 -m pip install -r requirements.txt
+
+    - name: Install project generator test dependencies
+      run: python3 -m pip install pytest
+
+    - name: Run pytest
+      run: cd pico-project-generator && pytest
+
     # - name: Configure CMake
     #   # Use a bash shell so we can use the same syntax for environment variable
     #   # access regardless of the host operating system
@@ -30,10 +42,7 @@ jobs:
     #   # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
     #   run: PICO_SDK_PATH=../../pico-sdk cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
-    # - name: Checkout pico-project-generator
-    #   uses: actions/checkout@v2
-    #   with:
-    #     path: pico-project-generator
+
 
     # - name: Build
     #   working-directory: ${{github.workspace}}/pico-examples/build

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,42 @@
+name: Run tests
+on: [push, pull_request]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout pico-sdk/develop
+      uses: actions/checkout@v2
+      with:
+        repository: raspberrypi/pico-sdk
+        ref: develop
+        path: pico-sdk
+
+    - name: Checkout pico-sdk submodules
+      run: cd pico-sdk && git submodule update --init
+
+    - name: Install toolchain dependencies
+      run:  sudo apt install cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential libstdc++-arm-none-eabi-newlib
+
+    - name: Hello
+      run: pwd && echo $SHELL 
+    # - name: Configure CMake
+    #   # Use a bash shell so we can use the same syntax for environment variable
+    #   # access regardless of the host operating system
+    #   shell: bash
+    #   working-directory: ${{github.workspace}}/pico-examples/build
+    #   # Note the current convention is to use the -S and -B options here to specify source 
+    #   # and build directories, but this is only available with CMake 3.13 and higher.  
+    #   # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+    #   run: PICO_SDK_PATH=../../pico-sdk cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+    # - name: Checkout pico-project-generator
+    #   uses: actions/checkout@v2
+    #   with:
+    #     path: pico-project-generator
+
+    # - name: Build
+    #   working-directory: ${{github.workspace}}/pico-examples/build
+    #   shell: bash
+    #   # Execute the build.  You can specify a specific target with "--target <NAME>"
+    #   run: cmake --build . --config $BUILD_TYPE --parallel ${{steps.core_count.outputs.output}}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
       run: cd pico-sdk && git submodule update --init
 
     - name: Install toolchain dependencies
-      run:  sudo apt install cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential libstdc++-arm-none-eabi-newlib
+      run:  sudo apt install -y cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential libstdc++-arm-none-eabi-newlib
 
     - name: Checkout pico-project-generator
       uses: actions/checkout@v2
@@ -31,21 +31,3 @@ jobs:
 
     - name: Run pytest
       run: cd pico-project-generator && pytest
-
-    # - name: Configure CMake
-    #   # Use a bash shell so we can use the same syntax for environment variable
-    #   # access regardless of the host operating system
-    #   shell: bash
-    #   working-directory: ${{github.workspace}}/pico-examples/build
-    #   # Note the current convention is to use the -S and -B options here to specify source 
-    #   # and build directories, but this is only available with CMake 3.13 and higher.  
-    #   # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-    #   run: PICO_SDK_PATH=../../pico-sdk cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE
-
-
-
-    # - name: Build
-    #   working-directory: ${{github.workspace}}/pico-examples/build
-    #   shell: bash
-    #   # Execute the build.  You can specify a specific target with "--target <NAME>"
-    #   run: cmake --build . --config $BUILD_TYPE --parallel ${{steps.core_count.outputs.output}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
-
+.pytest_cache
+__pycache__

--- a/README.md
+++ b/README.md
@@ -75,11 +75,7 @@ IDE Options | Description
 Create VSCode Project | As well as the CMake files, also create the appropriate Visual Studio Code project files.
 Debugger | Use the specified debugger in the IDE
 
+## Development
 
-
-
-
-
-
-
-
+* use a virtual environment to ensure dependencies are isolated from your system's
+* additional dependencies: `pip install pytest`

--- a/tests/test_pico_project.py
+++ b/tests/test_pico_project.py
@@ -1,2 +1,8 @@
-def test_basic_project():
-    assert 1 == 1
+import subprocess
+
+# basic integration testing
+def test_basic_project(tmp_path):
+    test_path = str(tmp_path / "test_project")
+    completed = subprocess.run(["python3", "pico_project.py", test_path])
+    assert completed.returncode == 0
+

--- a/tests/test_pico_project.py
+++ b/tests/test_pico_project.py
@@ -1,0 +1,1 @@
+def test_basic_project():

--- a/tests/test_pico_project.py
+++ b/tests/test_pico_project.py
@@ -1,1 +1,2 @@
 def test_basic_project():
+    assert 1 == 1


### PR DESCRIPTION
This PR adds the ability for integration tests to be run so that as we improve the project generator, we can guarantee the expected behavior without having to run it manually.

At the moment, this PR is pending some improvements to how paths are treated in the program (will come in another PR) so that we can distinguish  the base path from the output path.