### PR TITLE
Add support for Raspberry Pi Debug Probe

### DIFF
--- a/pico_project.py
+++ b/pico_project.py
@@ -75,8 +75,9 @@ stdlib_examples_list = {
     'div' :     ("Low level HW Divider",    "divider.c",        "hardware/divider.h",   "hardware_divider")
 }
 
-debugger_list = ["SWD", "PicoProbe"]
-debugger_config_list = ["raspberrypi-swd.cfg", "picoprobe.cfg"]
+debugger_list = ["SWD", "PicoProbe", "CMSIS-DAP Debug Probe"]
+debugger_config_list = ["raspberrypi-swd.cfg", "picoprobe.cfg", "cmsis-dap.cfg"]
+debug_server_args_list = ["", "", "\"-c\", \"adapter speed 5000\" "]
 
 DEFINES = 0
 INITIALISERS = 1
@@ -1120,6 +1121,7 @@ def generateProjectFiles(projectPath, projectName, sdkPath, projects, debugger):
     os.chdir(projectPath)
 
     deb = debugger_config_list[debugger]
+    server_args = debug_server_args_list[debugger]
 
     for p in projects :
         if p == 'vscode':
@@ -1137,6 +1139,9 @@ def generateProjectFiles(projectPath, projectName, sdkPath, projects, debugger):
                   '      "type": "cortex-debug",\n'
                   '      "servertype": "openocd",\n'
                   '      "gdbPath": "gdb-multiarch",\n'
+                  '      "serverArgs": [\n'
+                  f'        {server_args}\n'
+                  '      ],\n'
                   '      "device": "RP2040",\n'
                   '      "configFiles": [\n' + \
                   f'        "interface/{deb}",\n' + \


### PR DESCRIPTION
Added the option to use a Raspberry Pi Debug Probe (cmsis-dap debugger). This required the following:

(i) an additional parameter to set the adapter speed (as per the documentation). For other options (SWD and PicoProbe), serverArgs is an empty array.

(ii) the interface configuration file for the debug probe is set to cmsis-dap.cfg

Tested on a Pico W with Raspberry Pi Debug Probe. 
Tested that SWD and PicoProbe build. However, as I do not have the respective hardware, I am unable to confirm debug 

As an aside - I always have to delete the build folder and allow VS Code to recreate it. This seems to be something to do with CMake.