### PR TITLE
Expect tkinter import error - custom error message

### DIFF
--- a/pico_project.py
+++ b/pico_project.py
@@ -19,11 +19,19 @@ import platform
 import shlex
 import csv
 
-import tkinter as tk
-from tkinter import messagebox as mb
-from tkinter import filedialog as fd
-from tkinter import simpledialog as sd
-from tkinter import ttk
+# TODO: conditional import of tkinter if --gui option is used
+try:
+    import tkinter as tk
+    from tkinter import \
+        messagebox as mb, \
+        filedialog as fd, \
+        simpledialog as sd, \
+        ttk
+
+except ImportError:
+    print("[\033[91mERROR\033[0m] tkinter module not found")
+    sys.exit(1)
+
 
 CMAKELIST_FILENAME = 'CMakeLists.txt'
 CMAKECACHE_FILENAME = 'CMakeCache.txt'


### PR DESCRIPTION
## Description

This PR updates the way `tkinter` and related modules are imported to avoid crashing unexpectedly if `tkinter` is missing.

## Changes Made

- Reorganized `tkinter` imports for improved readability.
- Added error handling for `ImportError` when `tkinter` module is not found.

## Reason for the Changes

The added error handling provides a more user-friendly error message if the `tkinter` module is missing.
On many linux distros `tkinter` must be manually installed and on Windows it can be skipped with a custom install.

## Testing

I've tested this code on my local environment to ensure that the new imports work as expected and that the error handling is triggered when needed.

## Checklist

- [x] Code compiles and runs without errors
- [x] Existing functionality is not affected by the changes
- [x] Added appropriate error handling
- [x] Followed PEP 8 code style guidelines

Please review and merge this PR. Thank you!
